### PR TITLE
Handle concurrent writes to SQLite DB

### DIFF
--- a/cmd/witness-add-key/main.go
+++ b/cmd/witness-add-key/main.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 
@@ -27,7 +28,8 @@ func main() {
 		log.Fatalf("--public-key required to add log key to witness")
 	}
 
-	db, err := sql.Open("sqlite3", *dbPath)
+	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=1000", *dbPath)
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/witness-server/main.go
+++ b/cmd/witness-server/main.go
@@ -44,7 +44,11 @@ func main() {
 		log.Fatalf("--public-key required to initialize witness")
 	}
 
-	db, err := sql.Open("sqlite3", *dbPath)
+	// Enable Write-Ahead Logging for better concurrency, allowing reads during writes.
+	// A busy timeout is also set to prevent "database is locked" errors under contention,
+	// with writers waiting 1s before returning an error.
+	dsn := fmt.Sprintf("file:%s?_journal_mode=WAL&_busy_timeout=1000", *dbPath)
+	db, err := sql.Open("sqlite3", dsn)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
SQLite locks the database when writing, so if multiple logs need to be witnessed concurrently, only one write will succeed. We add two configurations to mitigate this: Write-ahead-logging to allow readers to access the database during a write, and a busy timeout so that a writer waits during contention rather than err out.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->